### PR TITLE
Documenting the new XML format

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -5,8 +5,8 @@ analyzer
 [analyzers]: #analyzer
 
 An **analyzer** is an [FST] intended primarily to convert
-[wordforms] into a [morphological analysis][analysis]. For example,
-if you apply the Cree analyzer to the wordform `ê-wâpamit`, it will
+[word forms] into a [morphological analysis][analysis]. For example,
+if you apply the Cree analyzer to the word form `ê-wâpamit`, it will
 return the analysis `PV/e+wâpamêw+V+TA+Cnj+Prs+3Sg+1SgO`, meaning
 the [lemma] is "wâpamêw", it\'s a **Transitive** **Animate**
 **Verb**, in the **Conjunct** form, in the **Present** tense with
@@ -24,7 +24,7 @@ orthography, make some common spelling mistakes, and may be lacking
 accents or aspiration marks where they would be required in
 "correct" text. Think [descriptive linguistics](https://en.wikipedia.org/wiki/Linguistic_description).
 In practice, we use **descriptive [analyzers]** to accept input and
-wordforms however people may type it---we allow for some wiggle-room
+[word forms][] however people may type it---we allow for some wiggle-room
 and forgive orthographic mistakes, in the hope that the FST will
 find the most appropriate analysis.
 
@@ -36,7 +36,7 @@ FST
 A **finite-state transducer** is a computational formalism that is
 useful for defining functions that convert an input string into an
 output string. In practice, linguists can use this to convert
-a [wordform] into its [lexeme]+[tags] and back again. See main
+a [word form] into its [lexeme]+[tags] and back again. See main
 article: [Finite-state transducer].
 
 generator
@@ -46,9 +46,9 @@ generator
 [generators]: #generator
 
 A **generator** is an [FST] that converts a
-[morphological analysis][analysis] into one or more [wordforms]. For
+[morphological analysis][analysis] into one or more [word forms]. For
 example, if you apply the Cree generator to the analysis
-`miskinâhk+N+A+Distr`, it will output the wordform `miskinâhkonâhk`.
+`miskinâhk+N+A+Distr`, it will output the word form `miskinâhkonâhk`.
 
 lemma
 --------
@@ -56,7 +56,7 @@ lemma
 [lemma]: #lemma
 
 A **lemma** is the "dictionary form" of a word. The lemma is usually
-a possible wordform of the word. In the case of Cree non-dependent
+a possible word form of the word. In the case of Cree non-dependent
 nouns, the lemma is the singular form of the noun. In the case of
 dependent nouns, the lemma is the singular first-person possessor form.
 In the case of VII/VAI/VTI verbs, it's the independent, present tense,
@@ -76,19 +76,20 @@ normative
 A **normative** [FST] operates on orthographically-correct text.
 This means, no spelling errors, accents in all the right places, and
 in the exactly correct letter case. In practice, we use **normative
-[generators]** that, given an [analysis], output a [wordforms] that
+[generators]** that, given an [analysis], output a [word forms] that
 is perfectly written and spelled-out.
 
-wordform
---------
+word form
+---------
 
-[wordform]: #wordform
+[word form]: #word-form
+[word forms]: #word-form
 
-A **wordform** is a specific grammatical realization of a word. For
-example, the [lemma] *eat* has several different wordforms including
-*eat*, *ate*, *eaten*, and *eats*. Likewise, the Cree word *wâpamêw* has
-many possible wordforms, including *kiwâpamin*, *kiwâpamatin*, and
-*wâpmaêw*, among many others.
+A **word form** (also spelled **wordform**) is a specific grammatical
+realization of a word. For example, the [lemma][] *eat* has several
+different word forms including *eat*, *ate*, *eaten*, and *eats*.
+Likewise, the Cree word *wâpamêw* has many possible word forms, including
+*kiwâpamin*, *kiwâpamatin*, and *wâpmaêw*, among many others.
 
 <!-- -->
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,12 +21,12 @@ descriptive
 A **descriptive** [FST] operates on orthographically dubious text.
 This means that the text may be written in a non-standard
 orthography, make some common spelling mistakes, and may be lacking
-accents or aspiration marks where they would be required in
+diacritics or aspiration ('h') where they would be required in
 "correct" text. Think [descriptive linguistics](https://en.wikipedia.org/wiki/Linguistic_description).
-In practice, we use **descriptive [analyzers]** to accept input and
-[word forms][] however people may type it---we allow for some wiggle-room
-and forgive orthographic mistakes, in the hope that the FST will
-find the most appropriate analysis.
+In practice, we use **descriptive [analyzers][]** to accept input and
+[word forms][] in whatever way people may type it---we allow for some
+wiggle-room and forgive spelling mistakes, in the hope that the FST
+will find the most appropriate analysis.
 
 FST
 ---
@@ -36,8 +36,14 @@ FST
 A **finite-state transducer** is a computational formalism that is
 useful for defining functions that convert an input string into an
 output string. In practice, linguists can use this to convert
-a [word form] into its [lexeme]+[tags] and back again. See main
+a [word form][] into its [lexeme]+[tags] and back again. See main
 article: [Finite-state transducer].
+
+When referring to "the FST", we (ALTLabbers) tend to mean the source
+code (`*.lexc`, `*.xfscript`, `*.regex`, `*.twolc` files) and resulting
+"compiled" data structures (`*.hfst`, `*.hfstol` files) we used to
+break-down and describe Plains Cree words.
+
 
 generator
 ---------
@@ -89,7 +95,7 @@ A **word form** (also spelled **wordform**) is a specific grammatical
 realization of a word. For example, the [lemma][] *eat* has several
 different word forms including *eat*, *ate*, *eaten*, and *eats*.
 Likewise, the Cree word *wâpamêw* has many possible word forms, including
-*kiwâpamin*, *kiwâpamatin*, and *wâpmaêw*, among many others.
+*kiwâpamin*, *kiwâpamatin*, and *wâpamêw*, among many others.
 
 <!-- -->
 

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -91,8 +91,11 @@ required child: `<title>`.
 ## `<e>`: dictionary entry
 
 Represents a single "word" in the dictionary. In _itwêwina_, each
-[lemma][] is assumed to have exactly one `<e>` entry and each `<e>`
-describes exactly one [lemma][].
+[lemma][] is assumed to be assigned to exactly one `<e>` entry and each
+`<e>` is assigned to exactly one [lemma][]. Since the `<t>` element
+indicates which dictionary source a particular translation/definition
+comes from, a single `<e>` element may contain content from multiple
+dictionary sources.
 
 An element may have more than one `<mg>` meaning, each with one or more
 `<t>` translations.
@@ -346,5 +349,6 @@ Here is a full lexicon with two sources, and three dictionary entries.
 ```
 
 [lemma]: ./glossary.md#lemma
+[word form]: ./glossary.md#word-form
 [original-docs]: http://giellatekno.uit.no/doc/dicts/dictionarywork.html
 [gt_dictionary.dtd]: https://victorio.uit.no/langtech/trunk/words/dicts/scripts/gt_dictionary.dtd

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -268,8 +268,7 @@ dictionary source(s) the plain-text translation is quoted from.
 
 ### Example
 
-The translation is "star" and it cited in two different dictionary
-sources:
+The translation is "star" and it cites two different dictionary sources:
 
 ```xml
 <t pos="N" sources="MD CW">star</t>
@@ -315,7 +314,7 @@ Here is a full lexicon with two sources, and three dictionary entries.
           <tg xml:lang="eng">
               <t pos="N" sources="MD">an arrow</t>
           </tg>
-          <tg>
+          <tg xml:lang="eng">
               <t pos="N" sources="CW">arrow, little arrow</t>
           </tg>
       </mg>

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -131,13 +131,13 @@ This noun can have multiple **meanings**:
 ```xml
   <mg>
     <tg xml:lang="eng">
-      <l sources="OED>the land alongside or sloping down to a river or lake</l>
+      <l sources="OED">the land alongside or sloping down to a river or lake</l>
     </tg>
   </mg>
 
   <mg>
     <tg xml:lang="eng">
-      <l sources="OED>A financial establishment that uses money deposited customers for investment [...] </l>
+      <l sources="OED">A financial establishment that uses money deposited customers for investment [...] </l>
     </tg>
   </mg>
 </e>
@@ -175,9 +175,9 @@ This verb can have multiple different meanings as well.
 
 > *Source*: [Oxford Living English Dictionary](https://en.oxforddictionaries.com/definition/bank#h47327854587960)
 
-The reason that there would be *two* different versions of "bank" is
-because, being from different parts-of-speech, they *inflect*
-differently.
+The reason that there would be *two* different lemmas (`<e>` elements)
+of "bank" is because, being from different parts-of-speech, they
+*inflect* differently.
 
 For example, the first `<e>`, with `<l pos="N">bank</l>` would inflect
 as:
@@ -196,10 +196,10 @@ Where as the second lemma `<l pos="V">bank</l>` inflect as:
 | 3Sg | banks   | banked | is banking          | will bank |
 | 1Pl | bank    | banked | are banking         | will bank |
 | 2Pl | bank    | banked | are banking         | will bank |
-| 3PL | bank    | banked | are banking         | will bank |
+| 3Pl | bank    | banked | are banking         | will bank |
 
-If it has a different inflectional paradigms, that means it's
-a different lemma!
+If it has a different inflectional paradigm, that means it's a different
+lemma!
 
 
 ## `<lg>`: lemma group

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -228,7 +228,7 @@ a particular meaning of a lemma.
    language code. Neahttadigisánit supports multiple translation
    languages, and thus these codes serve to differentiate what language
    the translation is written in. Currently itwêwina only supports `crk`
-   and `eng`. Thus, every `<t>` in the `crkeng.xml` dictionary will have
+   and `eng`. Thus, every `<tg>` in the `crkeng.xml` dictionary will have
    its `xml:lang="eng"`, as that is the only language it translates
    into.
 
@@ -340,6 +340,15 @@ Here is a full lexicon with two sources, and three dictionary entries.
    </e>
 </r>
 ```
+
+
+## Other elements and attributes
+
+These elements exist as an extension of the base dictionary format,
+however, are not officially supported:
+
+ - `<xg>` — example group (within `<tg>` or `<mg>`)
+ - **DEPRECATED** `<audio>` for use with SoundManager 2 (within `<xg>`)
 
 [lemma]: ./glossary.md#lemma
 [word form]: ./glossary.md#word-form

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -222,10 +222,15 @@ a particular meaning of a lemma.
 
  - one or more `<t>` translations
 
-### Optional attributes
+### Required attributes
 
- - `xml:lang=""` attribute. As of 2018-02-04, this attribute is ignored,
-   but it signifies what language the translation is written in.
+ - `xml:lang=""` attribute. This must be a three-letter ISO 639-3
+   language code. Neahttadigisánit supports multiple translation
+   languages, and thus these codes serve to differentiate what language
+   the translation is written in. Currently itwêwina only supports `crk`
+   and `eng`. Thus, every `<t>` in the `crkeng.xml` dictionary will have
+   its `xml:lang="eng"`, as that is the only language it translates
+   into.
 
 ### Example
 

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -155,8 +155,9 @@ In Plains Cree, the format of the **lemma category** is as follows:
 
 `ND?(A|I)-(1|2|3|4|4w|5|[?]|x)`
 
-**N**oun, **A**nimate or **I**nanimate, optionally dependent, followed
-by its noun class.
+**N**oun, optionally **D**ependent, **A**nimate or **I**nanimate.
+After the hyphen, the noun class follows.
+
 
 ### Verbs
 

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -5,15 +5,335 @@ The dictionaries are stored in an *ad hoc* dictionary format. There
 appears to be many different variants of the format originally designed
 in Giellatekno for Northern Saami.
 
-
 The original documentation for this format is [here][original-docs], but
 it's in Norwegian. There's also a tiny bit of documentation inline in
 [the DTD file][gt_dictionary.dtd], but, as it claims:
 
 > This document is not quite finished yet...
 
-Here's an informal description of the XML format.
+This is a description of the XML format, as it is used in itwêwina.
+A single dictionary XML file is a collection of **dictionary entries**
+(the _lexicon_) that have translations that are cited from one or more
+**dictionary sources**.
 
+The original XML dictionary format appears to support more use cases,
+but we have opted to focus on a few key use cases pertinent to Plains
+Cree.
+
+
+## `<r>`: The root element
+
+The root element is `<r>`. `<r>` contains:
+
+ - zero or more `<source>` elements
+ - zero or more `<e>` elements
+
+By convention, all `<source>` elements go near the top of the file, then
+the `<e>` elements follow alphabetically (according to their lemma).
+There will be far fewer `<source>` elements than `<e>` elements.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<r>
+    <!-- dictionary sources -->
+    <source id="..."> ... </source>
+    <source id="..."> ... </source>
+    <source id="..."> ... </source>
+
+    <!-- dictionary entries -->
+    <e> ... </e>
+    <e> ... </e>
+    <e> ... </e>
+</r>
+```
+
+
+## `<source>`: Dictionary source
+
+A **dictionary source** is the metadata for a particular source of
+definitions. Think of it like a bibliography entry.
+
+`<source>` contains one required attribute, `id=""`, and exactly one
+required child: `<title>`.
+
+### Required attributes
+
+ - `id=""` a machine-readable ID used by `<t>` elements to "cite" which
+   source it comes from. This is similar to `id=""` attributes in HTML.
+   The ID **SHOULD** be a short, ASCII-representable string, containing
+   only alphanumerics (U+0030—U+0039, U+0041–U+005A, U+0061–U+007A) and
+   the hyphen-minus character (U+002D). The ID **MUST NOT** contain any
+   spacing or format characters.
+
+### Required children
+
+ - `<title>`: contains the title of the dictionary source in plain text.
+
+### Example
+
+```xml
+<source id="CW">
+  <title>Cree : Words / nehiýawewin : itwēwina</title>
+</source>
+```
+
+`<t>` elements will cite this source using the id: `CW`.
+
+```xml
+<source id="MD">
+  <title>Maskwacîs Dictionary</title>
+</source>
+```
+
+`<t>` elements will cite this source using the id: `MD`.
+
+
+## `<e>`: dictionary entry
+
+Represents a single "word" in the dictionary. In _itwêwina_, each
+[lemma][] is assumed to have exactly one `<e>` entry and each `<e>`
+describes exactly one [lemma][].
+
+An element may have more than one `<mg>` meaning, each with one or more
+`<t>` translations.
+
+### Required children
+
+ - exactly one `<lg>` (lemma group) containing exactly one `<l>` lemma
+   and `<lc>` lemma category.
+ - one or more `<mg>` meaning groups.
+
+## `<lg>`: lemma group
+
+A **lemma group** describes a [lemma][]. A lemma group has two required
+children, and one optional child.
+
+### Required children
+
+ - exactly one `<l>` lemma element with a required `pos=""` attribute
+ - exactly one `<lc>` lemma comment element
+
+### Optional children
+
+ - one optional `<stem>` element
+
+### Example
+
+This describes "acâhkos", which is a noun.
+
+```xml
+<lg>
+  <l pos="N">acâhkos</l>
+  <lc>NA-1</lc>
+  <stem>acâhkos-</stem>
+</lg>
+```
+
+
+## `<l>`: lemma
+
+The text of this entry is the canonical [word form][] of the dictionary
+entry. Look-ups in the dictionary will match for this [word form][]
+exactly. In addition to the text of the entry, the `<l>` lemma element
+has one required attribute: `pos=""`, or the **part-of-speech**. The
+part-of-speech is typically "V" or "N", and certain searches will match
+on this value.
+
+
+## `<lc>`: lemma category
+
+The **lemma category** determines which layout will be be used when
+rendering the paradigm.
+
+In Plains Cree, the format of the **lemma category** is as follows:
+
+### Nouns
+
+`ND?(A|I)-(1|2|3|4|4w|5|[?]|x)`
+
+**N**oun, **A**nimate or **I**nanimate, optionally dependent, followed
+by its noun class.
+
+### Verbs
+
+`V{class}-(n|v|1|2|3|4|5)`
+
+**V**erb, followed by its transitivity, and the animacy of its
+dependents. Note, that abbreviations are historical Algonquian
+linguistics terminology, and Plains Cree verbs can be viewed as
+categorized by the quantity (0, 1, or 2) of its animate dependents (its
+*valency*). After the hyphen, the verb class follows.
+
+ - VII — verb inanimate    intransitive (0 animate dependents)
+ - VAI – verb intransitive animate      (1 animate dependent)
+ - VTI - verb transitive   inanimate    (1 animate dependent)
+ - VTA — verb transitive   animate      (2 animate dependents)
+
+
+### Other
+
+`IPC` — any word that does not inflect.
+
+## `<stem>`: linguistic stem
+
+The stem is used in the FST to transduce into inflected word forms.
+Note that the stem **MAY NOT** be a valid [word form][] by itself.
+
+
+## `<mg>`: meaning group
+
+A **meaning group** contains one or more different possible meanings of
+the lemma.
+
+## Required children
+
+ - one or more `<tg>` translation groups.
+
+
+### Example
+
+There are two separate meanings of this entry. One is "s/he shakes s.t.", as
+listed in the `MD` dictionary source. The other meaning is "s/he rubs s.t.",
+as listed in the `CW` dictionary source.
+
+```xml
+<mg>
+  <tg xml:lang="eng">
+    <t pos="V" sources="MD">s/he shakes s.t.</t>
+  </tg>
+</mg>
+<mg>
+  <tg xml:lang="eng">
+    <t pos="V" sources="CW">s/he rubs s.t.</t>
+  </tg>
+</mg>
+```
+
+## `<tg>`: translation group
+
+A **translation group** lists all the different translations of
+a particular meaning of a lemma.
+
+### Required children
+
+ - one or more `<t>` translations
+
+### Optional attributes
+
+ - `xml:lang=""` attribute. As of 2018-02-04, this attribute is ignored,
+   but it signifies what language the translation is written in.
+
+### Example
+
+There is one meaning, but the `MD` source translates it as "an arrow",
+while the `CW` source translates it as "arrow, little arrow".
+
+```xml
+<mg>
+  <tg xml:lang="eng">
+    <t pos="N" sources="MD">an arrow</t>
+  </tg>
+  <tg>
+    <t pos="N" sources="CW">arrow, little arrow</t>
+  </tg>
+</mg>
+```
+
+
+## `<t>`: translation
+
+A translation, as quoted from one or more of the `<source>` dictionary
+sources. The translation text is the plain text translation of the
+lemma, for *one* given meaning. The translation **MUST** indicate the
+part-of-speech in the target language; it **MUST** also cite which
+dictionary source(s) the plain-text translation is quoted from.
+
+### Required attributes
+
+ - `pos=""` the part-of-speech in the target language
+ - `source=""` a space-separated list containing `<source>` IDs. This
+   means that this particular translation came from the source(s)
+   indicated. If at least one `<source>` element exists in `<r>`, each
+   `<t>` **MUST** list at least one source ID. If no `<source>` element
+   exists in `<r>`, the `sources=""` attribute **MAY** be absent.
+
+### Example
+
+The translation is "star" and it cited in two different dictionary
+sources:
+
+```xml
+<t pos="N" sources="MD CW">star</t>
+```
+
+
+## Complete dictionary example
+
+Here is a full lexicon with two sources, and three dictionary entries.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<r>
+   <!-- The dictionary sources -->
+   <source id="CW">
+      <title>Cree : Words / nehiýawewin : itwēwina</title>
+   </source>
+   <source id="MD">
+      <title>Maskwacîs Dictionary</title>
+   </source>
+
+   <!-- The dictionary entries -->
+   <e>
+      <lg>
+         <l pos="N">acâhkos</l>
+         <lc>NA-1</lc>
+         <stem>acâhkos-</stem>
+      </lg>
+      <mg>
+          <tg xml:lang="eng">
+              <t pos="N" sources="MD CW">star</t>
+          </tg>
+      </mg>
+   </e>
+
+   <e>
+      <lg>
+         <l pos="N">acosis</l>
+         <lc>NA-1</lc>
+         <stem>acâhkos-</stem>
+      </lg>
+      <mg>
+          <tg xml:lang="eng">
+              <t pos="N" sources="MD">an arrow</t>
+          </tg>
+          <tg>
+              <t pos="N" sources="CW">arrow, little arrow</t>
+          </tg>
+      </mg>
+   </e>
+
+   <e>
+      <lg>
+         <l pos="V">mimikopitam</l>
+         <lc>VTI-1</lc>
+         <stem>mimikopit-</stem>
+      </lg>
+      <mg>
+          <tg xml:lang="eng">
+              <t pos="V" sources="MD">He shakes it.</t>
+          </tg>
+      </mg>
+      <mg>
+          <tg xml:lang="eng">
+              <t pos="V" sources="CW">s/he rubs s.t.</t>
+          </tg>
+      </mg>
+   </e>
+</r>
+```
+
+
+## Other examples
 
 ```xml
 <e src="the title of the source dictionary">
@@ -22,11 +342,9 @@ Here's an informal description of the XML format.
         <lc>NDI-1</lc>   <!-- the "lemma comment" --
                               crk uses this to disambiguate forms within parts-of-speech. -->
     </lg>
-    <mg><!-- the definitions, but I don't care about this here --></mg>
 </e>
 ```
 
-Hey, guess what! I also didn't document all of this yet. Pester me in the GitHub issues to finish this: <https://github.com/UAlbertaALTLab/itwewina/issues/63>
-
+[lemma]: ./glossary.md#lemma
 [original-docs]: http://giellatekno.uit.no/doc/dicts/dictionarywork.html
 [gt_dictionary.dtd]: https://victorio.uit.no/langtech/trunk/words/dicts/scripts/gt_dictionary.dtd

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -84,14 +84,16 @@ required child: `<title>`.
 
 ```xml
 <source id="MD">
-  <title>Maskwacîs Dictionary</title>
+  <title>Maskwacîs Cree Dictionary</title>
 </source>
 ```
 
 
 ## `<e>`: dictionary entry
 
-Represents a single "word" in the dictionary. In _itwêwina_, each
+Represents a single lemma in the dictionary. In laymen's terms,
+this is like a word in one particular part of speech e.g., "bank"
+(Noun). In _itwêwina_, each
 [lemma][] is assumed to be assigned to exactly one `<e>` entry and each
 `<e>` is assigned to exactly one [lemma][]. Since the `<t>` element
 indicates which dictionary source a particular translation/definition
@@ -106,6 +108,99 @@ An element may have more than one `<mg>` meaning, each with one or more
  - exactly one `<lg>` (lemma group) containing exactly one `<l>` lemma
    and `<lc>` lemma category.
  - one or more `<mg>` meaning groups.
+
+### Example
+
+Consider the following English utterance: "bank".
+
+
+It can be interpreted as a **noun**:
+
+```
+<e>
+  <lg>
+    <l pos="N">bank</l>
+    <lc>Noun/regular-unvoiced</lc>
+    <stem>bank</stem>
+  </lg>
+  <!-- continued in next example -->
+```
+
+This noun can have multiple **meanings**:
+
+```xml
+  <mg>
+    <tg xml:lang="eng">
+      <l sources="OED>the land alongside or sloping down to a river or lake</l>
+    </tg>
+  </mg>
+
+  <mg>
+    <tg xml:lang="eng">
+      <l sources="OED>A financial establishment that uses money deposited customers for investment [...] </l>
+    </tg>
+  </mg>
+</e>
+```
+
+> *Source*: [Oxford Living English Dictionary](https://en.oxforddictionaries.com/definition/bank#h47327854587960)
+
+A different `<e>` interprets "bank" as a **verb**:
+
+```xml
+<e>
+  <lg>
+    <l pos="N">bank</l>
+    <lc>Verb/regular</lc>
+    <stem>bank</stem>
+  </lg>
+  <!-- continued in next example -->
+```
+
+This verb can have multiple different meanings as well.
+
+```xml
+  <mg>
+    <tg xml:lang="eng">
+      <l sources="OED">Heap a substance into a mass or mound</l>
+    </tg>
+  </mg>
+  <mg>
+    <tg xml:lang="eng">
+      <l sources="OED">(with reference to an aircraft or vehicle) tilt or cause to tilt sideways in making a turn</l>
+    </tg>
+  </mg>
+</e>
+```
+
+> *Source*: [Oxford Living English Dictionary](https://en.oxforddictionaries.com/definition/bank#h47327854587960)
+
+The reason that there would be *two* different versions of "bank" is
+because, being from different parts-of-speech, they *inflect*
+differently.
+
+For example, the first `<e>`, with `<l pos="N">bank</l>` would inflect
+as:
+
+|           | Singular | Plural |
+|-----------|----------|--------|
+| Plain     | bank     | banks  |
+| Posessive | bank's   | banks' |
+
+Where as the second lemma `<l pos="V">bank</l>` inflect as:
+
+|     | Present | Past   | Present progressive | Future    |
+|-----|---------|--------|---------------------|-----------|
+| 1Sg | bank    | banked | am banking          | will bank |
+| 2Sg | bank    | banked | are banking         | will bank |
+| 3Sg | banks   | banked | is banking          | will bank |
+| 1Pl | bank    | banked | are banking         | will bank |
+| 2Pl | bank    | banked | are banking         | will bank |
+| 3PL | bank    | banked | are banking         | will bank |
+
+If it has a different inflectional paradigms, that means it's
+a different lemma!
+
 
 ## `<lg>`: lemma group
 
@@ -164,15 +259,15 @@ After the hyphen, the noun class follows.
 `V{class}-(n|v|1|2|3|4|5)`
 
 **V**erb, followed by its transitivity, and the animacy of its
-dependents. Note, that abbreviations are historical Algonquian
+arguments. Note, that abbreviations are historical Algonquian
 linguistics terminology; Plains Cree verbs can be viewed as
-categorized by the quantity (0, 1, or 2) of its animate dependents (its
+categorized by the quantity (0, 1, or 2) of its animate arguments (its
 *valency*). After the hyphen, the verb class follows.
 
- - VII — verb inanimate    intransitive (0 animate dependents)
- - VAI – verb intransitive animate      (1 animate dependent)
- - VTI - verb transitive   inanimate    (1 animate dependent)
- - VTA — verb transitive   animate      (2 animate dependents)
+ - VII — verb inanimate    intransitive (0 animate arguments)
+ - VAI – verb intransitive animate      (1 animate argument)
+ - VTI - verb transitive   inanimate    (1 animate argument)
+ - VTA — verb transitive   animate      (2 animate arguments)
 
 
 ### Other
@@ -188,7 +283,8 @@ Note that the stem **MAY NOT** be a valid [word form][] by itself.
 ## `<mg>`: meaning group
 
 A **meaning group** contains one or more different possible meanings of
-the lemma.
+the lemma. An entry would use more than one meaning groups when the
+meanings are not obviously related.
 
 ## Required children
 
@@ -288,7 +384,7 @@ Here is a full lexicon with two sources, and three dictionary entries.
       <title>Cree : Words / nehiýawewin : itwēwina</title>
    </source>
    <source id="MD">
-      <title>Maskwacîs Dictionary</title>
+      <title>Maskwacîs Cree Dictionary</title>
    </source>
 
    <!-- The dictionary entries -->

--- a/docs/xml-dictionary.md
+++ b/docs/xml-dictionary.md
@@ -11,7 +11,7 @@ it's in Norwegian. There's also a tiny bit of documentation inline in
 
 > This document is not quite finished yet...
 
-This is a description of the XML format, as it is used in itwêwina.
+This is a description of the XML format as it is used in itwêwina.
 A single dictionary XML file is a collection of **dictionary entries**
 (the _lexicon_) that have translations that are cited from one or more
 **dictionary sources**.
@@ -71,21 +71,22 @@ required child: `<title>`.
 
 ### Example
 
+`<t>` elements will cite this source using the id `CW`:
+
 ```xml
 <source id="CW">
   <title>Cree : Words / nehiýawewin : itwēwina</title>
 </source>
 ```
 
-`<t>` elements will cite this source using the id: `CW`.
+`<t>` elements will cite this source using the id `MD`:
+
 
 ```xml
 <source id="MD">
   <title>Maskwacîs Dictionary</title>
 </source>
 ```
-
-`<t>` elements will cite this source using the id: `MD`.
 
 
 ## `<e>`: dictionary entry
@@ -114,7 +115,7 @@ children, and one optional child.
 ### Required children
 
  - exactly one `<l>` lemma element with a required `pos=""` attribute
- - exactly one `<lc>` lemma comment element
+ - exactly one `<lc>` lemma content element
 
 ### Optional children
 
@@ -122,7 +123,7 @@ children, and one optional child.
 
 ### Example
 
-This describes "acâhkos", which is a noun.
+This describes "acâhkos", which is an animate noun:
 
 ```xml
 <lg>
@@ -140,7 +141,7 @@ entry. Look-ups in the dictionary will match for this [word form][]
 exactly. In addition to the text of the entry, the `<l>` lemma element
 has one required attribute: `pos=""`, or the **part-of-speech**. The
 part-of-speech is typically "V" or "N", and certain searches will match
-on this value.
+on this value exactly.
 
 
 ## `<lc>`: lemma category
@@ -163,7 +164,7 @@ by its noun class.
 
 **V**erb, followed by its transitivity, and the animacy of its
 dependents. Note, that abbreviations are historical Algonquian
-linguistics terminology, and Plains Cree verbs can be viewed as
+linguistics terminology; Plains Cree verbs can be viewed as
 categorized by the quantity (0, 1, or 2) of its animate dependents (its
 *valency*). After the hyphen, the verb class follows.
 
@@ -333,19 +334,6 @@ Here is a full lexicon with two sources, and three dictionary entries.
       </mg>
    </e>
 </r>
-```
-
-
-## Other examples
-
-```xml
-<e src="the title of the source dictionary">
-    <lg>
-        <l pos="N">mitâs</l> <!-- Lemma with its part-of-speech as an attribute -->
-        <lc>NDI-1</lc>   <!-- the "lemma comment" --
-                              crk uses this to disambiguate forms within parts-of-speech. -->
-    </lg>
-</e>
 ```
 
 [lemma]: ./glossary.md#lemma


### PR DESCRIPTION
Here is the documentation for the new XML dictionary format, incorporating multiple dictionary sources (#61). @aarppe, please [have a look](https://github.com/UAlbertaALTLab/itwewina/pull/87/files?short_path=ca37dd8#diff-ca37dd89d4af6ecf0793313a83de51b1) and make comments inline. Also addresses #63.